### PR TITLE
Project only support python 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Until then, the best resource is to refer to the [API docs](https://raghakot.git
 ## Installation
 
 1) Install [keras](https://github.com/fchollet/keras/blob/master/README.md#installation) 
-with theano or tensorflow backend. Note that this library requires Keras > 2.0
+with theano or tensorflow backend. Note that this library requires Keras > 2.0 and Python = 2.x
 
 2) Install keras-text
 > From sources


### PR DESCRIPTION
'dict_values' object does not support indexing @keras_text\models\sentence_model.py:38 limits this librabry to python 2.x

import error for @keras_text\models\__init__.py.

Library should de-list py3 support from PYPI while this persists.